### PR TITLE
Make details button able to be opened in new tab.

### DIFF
--- a/src/main/webapp/scripts/app/document/docUnitEdit.html
+++ b/src/main/webapp/scripts/app/document/docUnitEdit.html
@@ -28,7 +28,7 @@
                 <button
                     type="button"
                     class="btn btn-sem2 btn-xs"
-                    ng-click="goToAllOperations()"
+                    ng-click="goToAllOperations($event)"
                     ng-disabled="!docUnit || !docUnit.identifier"
                     uib-tooltip="{{::'Détails' | translate}}"
                     tooltip-append-to-body="true"
@@ -303,7 +303,7 @@
                                                 <button
                                                     type="button"
                                                     class="btn btn-sem2 btn-xs"
-                                                    ng-click="goToAllOperations('CHECK')"
+                                                    ng-click="goToAllOperations($event, 'CHECK')"
                                                     ng-disabled="!docUnit || !docUnit.identifier || !loaded"
                                                     uib-tooltip="{{::'Voir le document' | translate}}"
                                                 >

--- a/src/main/webapp/scripts/app/document/docUnitEditCtrl.js
+++ b/src/main/webapp/scripts/app/document/docUnitEditCtrl.js
@@ -10,6 +10,7 @@
         $q,
         $routeParams,
         $scope,
+        $window,
         $timeout,
         codeSrvc,
         WebsocketSrvc,
@@ -467,11 +468,23 @@
             $location.search({});
             $location.path('/document/docunit');
         };
-        $scope.goToAllOperations = function (tab) {
-            if (tab) {
-                $location.path('/document/all_operations/' + $scope.docUnit.identifier).search({ tab: tab });
+
+        /**
+         * Open the document operations to the tab provided or the Doc unit tab by default.
+         * If the event is a ctrl click or a middle click opens in a new tab.
+         * @param {Event} event - the click event.
+         * @param {String} tab - the operation tab to go to.
+         */
+        $scope.goToAllOperations = function (event, tab) {
+            var path = '/document/all_operations/' + $scope.docUnit.identifier;
+            var search = '';
+            if ((event.ctrlKey && event.button == 0) || (event.button == 1)) {
+                $window.open('#' + path);
             } else {
-                $location.path('/document/all_operations/' + $scope.docUnit.identifier).search('');
+                if (tab) {
+                    search = { tab: tab };
+                }
+                $location.path(path).search(search);
             }
         };
 


### PR DESCRIPTION
Closes #1 
Make the details button able to open the document unit details content in a new tab by using `Ctrl+Left Click`.

Test plan:
- Create a User with the necessary rights to create a document unit and login as the user if you don't have already one.
- Create a basic document unit.
- `Ctrl+Left Click` on the details button.

The details page with all the tabs should open in a new tab.