### PR TITLE
MT52421: Add a new permission for admin tools

### DIFF
--- a/src/main/java/org/numahop/numahop/service/workflow/ui/UIWorkflowService.java
+++ b/src/main/java/org/numahop/numahop/service/workflow/ui/UIWorkflowService.java
@@ -235,7 +235,8 @@ public class UIWorkflowService {
 	}
 
 	/**
-	 * SUPER_ADMIN ou ADMIN_TOOLS: Force la validation d'une etape et avance... !! AUCUN CONTROLE
+	 * SUPER_ADMIN ou ADMIN_TOOLS: Force la validation d'une etape et avance... !! AUCUN
+	 * CONTROLE
 	 * @param docUnitIds
 	 */
 	public void validDocWorkflowState(final String stateId, final List<String> docUnitIds) {
@@ -256,8 +257,8 @@ public class UIWorkflowService {
 	}
 
 	/**
-	 * SUPER_ADMIN ou ADMIN_TOOLS: Reinitialisation d'une etape Possible uniquement si : - l'étape est
-	 * passée - l'étape qui suit est en cours ou en attente.
+	 * SUPER_ADMIN ou ADMIN_TOOLS: Reinitialisation d'une etape Possible uniquement si : -
+	 * l'étape est passée - l'étape qui suit est en cours ou en attente.
 	 * @param docUnitIds
 	 */
 	public void reinitDocWorkflowState(final String stateId, final List<String> docUnitIds) {

--- a/src/main/java/org/numahop/numahop/service/workflow/ui/UIWorkflowService.java
+++ b/src/main/java/org/numahop/numahop/service/workflow/ui/UIWorkflowService.java
@@ -223,7 +223,7 @@ public class UIWorkflowService {
 
 	/* ========= ADMIN UTILS ================= */
 	/**
-	 * ADMIN only : annule tout !! AUCUN CONTROLE
+	 * SUPER_ADMIN ou ADMIN_TOOLS: annule tout !! AUCUN CONTROLE
 	 * @param docUnitIds
 	 */
 	@Transactional
@@ -235,7 +235,7 @@ public class UIWorkflowService {
 	}
 
 	/**
-	 * ADMIN only : Force la validation d'une etape et avance... !! AUCUN CONTROLE
+	 * SUPER_ADMIN ou ADMIN_TOOLS: Force la validation d'une etape et avance... !! AUCUN CONTROLE
 	 * @param docUnitIds
 	 */
 	public void validDocWorkflowState(final String stateId, final List<String> docUnitIds) {
@@ -256,7 +256,7 @@ public class UIWorkflowService {
 	}
 
 	/**
-	 * ADMIN only : Reinitialisation d'une etape Possible uniquement si : - l'étape est
+	 * SUPER_ADMIN ou ADMIN_TOOLS: Reinitialisation d'une etape Possible uniquement si : - l'étape est
 	 * passée - l'étape qui suit est en cours ou en attente.
 	 * @param docUnitIds
 	 */

--- a/src/main/java/org/numahop/numahop/web/rest/administration/security/AuthorizationConstants.java
+++ b/src/main/java/org/numahop/numahop/web/rest/administration/security/AuthorizationConstants.java
@@ -14,7 +14,7 @@ public final class AuthorizationConstants {
 	/**
 	 * Accès aux outils d'administration
 	 */
-	public static final String ADMIN_TOOLS = "ADMIN_TOOLS";
+	public static final String ADMIN_TOOLS = "ADMIN-TOOLS";
 
 	/**
 	 * Autorisation ajoutée automatiquement au super administrateur : ne correspond pas à

--- a/src/main/java/org/numahop/numahop/web/rest/administration/security/AuthorizationConstants.java
+++ b/src/main/java/org/numahop/numahop/web/rest/administration/security/AuthorizationConstants.java
@@ -12,6 +12,11 @@ public final class AuthorizationConstants {
 	public static final String SUPER_ADMIN = "SUPER_ADMIN";
 
 	/**
+	 * Accès aux outils d'administration
+	 */
+	public static final String ADMIN_TOOLS = "ADMIN_TOOLS";
+
+	/**
 	 * Autorisation ajoutée automatiquement au super administrateur : ne correspond pas à
 	 * une authorisation en BD => donne acces aux management protected endPoints
 	 */

--- a/src/main/java/org/numahop/numahop/web/rest/lot/LotController.java
+++ b/src/main/java/org/numahop/numahop/web/rest/lot/LotController.java
@@ -440,7 +440,7 @@ public class LotController extends AbstractRestController {
 	 */
 	@RequestMapping(method = RequestMethod.POST, params = { "cloturelot" })
 	@Timed
-	@RolesAllowed(AuthorizationConstants.SUPER_ADMIN)
+	@RolesAllowed({AuthorizationConstants.SUPER_ADMIN, AuthorizationConstants.ADMIN_TOOLS})
 	public ResponseEntity<List<ResultAdminLotDTO>> closeLot(@RequestBody final List<String> lotsIds) {
 
 		final List<ResultAdminLotDTO> results = new ArrayList<>();
@@ -458,7 +458,7 @@ public class LotController extends AbstractRestController {
 	 */
 	@RequestMapping(method = RequestMethod.POST, params = { "decloturelot" })
 	@Timed
-	@RolesAllowed(AuthorizationConstants.SUPER_ADMIN)
+	@RolesAllowed({AuthorizationConstants.SUPER_ADMIN, AuthorizationConstants.ADMIN_TOOLS})
 	public ResponseEntity<List<ResultAdminLotDTO>> declotureLot(@RequestBody final List<String> lotsIds) {
 		final List<ResultAdminLotDTO> results = new ArrayList<>();
 		lotsIds.forEach(id -> {

--- a/src/main/java/org/numahop/numahop/web/rest/lot/LotController.java
+++ b/src/main/java/org/numahop/numahop/web/rest/lot/LotController.java
@@ -440,7 +440,7 @@ public class LotController extends AbstractRestController {
 	 */
 	@RequestMapping(method = RequestMethod.POST, params = { "cloturelot" })
 	@Timed
-	@RolesAllowed({AuthorizationConstants.SUPER_ADMIN, AuthorizationConstants.ADMIN_TOOLS})
+	@RolesAllowed({ AuthorizationConstants.SUPER_ADMIN, AuthorizationConstants.ADMIN_TOOLS })
 	public ResponseEntity<List<ResultAdminLotDTO>> closeLot(@RequestBody final List<String> lotsIds) {
 
 		final List<ResultAdminLotDTO> results = new ArrayList<>();
@@ -458,7 +458,7 @@ public class LotController extends AbstractRestController {
 	 */
 	@RequestMapping(method = RequestMethod.POST, params = { "decloturelot" })
 	@Timed
-	@RolesAllowed({AuthorizationConstants.SUPER_ADMIN, AuthorizationConstants.ADMIN_TOOLS})
+	@RolesAllowed({ AuthorizationConstants.SUPER_ADMIN, AuthorizationConstants.ADMIN_TOOLS })
 	public ResponseEntity<List<ResultAdminLotDTO>> declotureLot(@RequestBody final List<String> lotsIds) {
 		final List<ResultAdminLotDTO> results = new ArrayList<>();
 		lotsIds.forEach(id -> {

--- a/src/main/java/org/numahop/numahop/web/rest/workflow/WorkflowController.java
+++ b/src/main/java/org/numahop/numahop/web/rest/workflow/WorkflowController.java
@@ -224,7 +224,7 @@ public class WorkflowController extends AbstractRestController {
 	 */
 	@RequestMapping(method = RequestMethod.POST, params = { "endAllDocWorkflows" })
 	@ResponseStatus(HttpStatus.OK)
-	@RolesAllowed(AuthorizationConstants.SUPER_ADMIN)
+	@RolesAllowed({AuthorizationConstants.SUPER_ADMIN, AuthorizationConstants.ADMIN_TOOLS})
 	@Timed
 	public ResponseEntity<?> endAllDocWorkflows(@RequestBody final List<String> docUnitIds) {
 		uiService.endAllDocWorkflows(docUnitIds);
@@ -233,7 +233,7 @@ public class WorkflowController extends AbstractRestController {
 
 	@RequestMapping(method = RequestMethod.POST, params = { "validDocWorkflowState" })
 	@ResponseStatus(HttpStatus.OK)
-	@RolesAllowed(AuthorizationConstants.SUPER_ADMIN)
+	@RolesAllowed({AuthorizationConstants.SUPER_ADMIN, AuthorizationConstants.ADMIN_TOOLS})
 	public ResponseEntity<?> validDocWorkflowState(@RequestBody final List<String> docUnitIds) {
 
 		final String stateId = docUnitIds.remove(docUnitIds.size() - 1);
@@ -243,7 +243,7 @@ public class WorkflowController extends AbstractRestController {
 
 	@RequestMapping(method = RequestMethod.POST, params = { "reinitDocWorkflowState" })
 	@ResponseStatus(HttpStatus.OK)
-	@RolesAllowed(AuthorizationConstants.SUPER_ADMIN)
+	@RolesAllowed({AuthorizationConstants.SUPER_ADMIN, AuthorizationConstants.ADMIN_TOOLS})
 	public ResponseEntity<?> reinitDocWorkflowState(@RequestBody final List<String> docUnitIds) {
 
 		final String stateId = docUnitIds.remove(docUnitIds.size() - 1);

--- a/src/main/java/org/numahop/numahop/web/rest/workflow/WorkflowController.java
+++ b/src/main/java/org/numahop/numahop/web/rest/workflow/WorkflowController.java
@@ -224,7 +224,7 @@ public class WorkflowController extends AbstractRestController {
 	 */
 	@RequestMapping(method = RequestMethod.POST, params = { "endAllDocWorkflows" })
 	@ResponseStatus(HttpStatus.OK)
-	@RolesAllowed({AuthorizationConstants.SUPER_ADMIN, AuthorizationConstants.ADMIN_TOOLS})
+	@RolesAllowed({ AuthorizationConstants.SUPER_ADMIN, AuthorizationConstants.ADMIN_TOOLS })
 	@Timed
 	public ResponseEntity<?> endAllDocWorkflows(@RequestBody final List<String> docUnitIds) {
 		uiService.endAllDocWorkflows(docUnitIds);
@@ -233,7 +233,7 @@ public class WorkflowController extends AbstractRestController {
 
 	@RequestMapping(method = RequestMethod.POST, params = { "validDocWorkflowState" })
 	@ResponseStatus(HttpStatus.OK)
-	@RolesAllowed({AuthorizationConstants.SUPER_ADMIN, AuthorizationConstants.ADMIN_TOOLS})
+	@RolesAllowed({ AuthorizationConstants.SUPER_ADMIN, AuthorizationConstants.ADMIN_TOOLS })
 	public ResponseEntity<?> validDocWorkflowState(@RequestBody final List<String> docUnitIds) {
 
 		final String stateId = docUnitIds.remove(docUnitIds.size() - 1);
@@ -243,7 +243,7 @@ public class WorkflowController extends AbstractRestController {
 
 	@RequestMapping(method = RequestMethod.POST, params = { "reinitDocWorkflowState" })
 	@ResponseStatus(HttpStatus.OK)
-	@RolesAllowed({AuthorizationConstants.SUPER_ADMIN, AuthorizationConstants.ADMIN_TOOLS})
+	@RolesAllowed({ AuthorizationConstants.SUPER_ADMIN, AuthorizationConstants.ADMIN_TOOLS })
 	public ResponseEntity<?> reinitDocWorkflowState(@RequestBody final List<String> docUnitIds) {
 
 		final String stateId = docUnitIds.remove(docUnitIds.size() - 1);

--- a/src/main/resources/config/liquibase/changelog/db-changelog-MT52421-add-admin-tools-authorization.xml
+++ b/src/main/resources/config/liquibase/changelog/db-changelog-MT52421-add-admin-tools-authorization.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd"
+>
+
+    <!-- Chargement des données du module Usager -->
+    <changeSet id="numahop-MT52421" author="biblibre">
+        <loadData encoding="UTF-8" separator=";" file="config/liquibase/numahop/user/authorization-003.csv" tableName="user_authorization" />
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -266,4 +266,7 @@
 
     <!-- ajout données par defaut -->
     <include file="classpath:config/liquibase/changelog/db-changelog-update-parameter-cines-values.xml" relativeToChangelogFile="false" />
+
+    <!-- MT52421: Add a new permission for admin tools -->
+    <include file="classpath:config/liquibase/changelog/db-changelog-MT52421-add-admin-tools-authorization.xml" relativeToChangelogFile="false" />
 </databaseChangeLog>

--- a/src/main/resources/config/liquibase/numahop/user/authorization-003.csv
+++ b/src/main/resources/config/liquibase/numahop/user/authorization-003.csv
@@ -1,0 +1,2 @@
+module;identifier;code;label;description;version
+ADMINISTRATION;ADMIN-TOOLS;ADMIN-TOOLS;Accès aux outils d'administration;Accès aux outils d'administration;0

--- a/src/main/webapp/scripts/app/admin/utilsprojectlot/utilsProjectLot.js
+++ b/src/main/webapp/scripts/app/admin/utilsprojectlot/utilsProjectLot.js
@@ -8,7 +8,7 @@
             title: gettext('Outils'),
             reloadOnSearch: false,
             access: {
-                authorizedRoles: [USER_ROLES.SUPER_ADMIN],
+                authorizedRoles: [USER_ROLES.ADMIN_TOOLS],
             },
         });
     });

--- a/src/main/webapp/scripts/app/admin/utilsworkflow/utilsWorkflow.js
+++ b/src/main/webapp/scripts/app/admin/utilsworkflow/utilsWorkflow.js
@@ -8,7 +8,7 @@
             title: gettext('Outils'),
             reloadOnSearch: false,
             access: {
-                authorizedRoles: [USER_ROLES.SUPER_ADMIN],
+                authorizedRoles: [USER_ROLES.ADMIN_TOOLS],
             },
         });
     });

--- a/src/main/webapp/scripts/app/configuration/appconfiguration.html
+++ b/src/main/webapp/scripts/app/configuration/appconfiguration.html
@@ -195,7 +195,7 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="administrationBlock" sem-roles-allowed="SUPER_ADMIN">
+                        <div class="administrationBlock" sem-roles-allowed="ADMIN_TOOLS">
                             <div class="administrationBlockTitle">
                                 <span translate>Outils Admin</span>
                             </div>

--- a/src/main/webapp/scripts/app/main/menuLeft.html
+++ b/src/main/webapp/scripts/app/main/menuLeft.html
@@ -86,7 +86,7 @@
             <li sem-roles-allowed="DEL_HAB8"><a href="#/statistics/dashboard_progress/" translate>Avancement des projets</a></li>
         </ul>
     </li>
-    <li sem-roles-allowed="DOC_UNIT_HAB5,CHECK_HAB0,TPL_HAB0,WORKFLOW_HAB4,SUPER_ADMIN,EXC_HAB0,FTP_HAB0,CONF_INTERNET_ARCHIVE_HAB0,MAIL_HAB0,SFTP_HAB0,MAP_HAB0">
+    <li sem-roles-allowed="DOC_UNIT_HAB5,CHECK_HAB0,TPL_HAB0,WORKFLOW_HAB4,SUPER_ADMIN,EXC_HAB0,FTP_HAB0,CONF_INTERNET_ARCHIVE_HAB0,MAIL_HAB0,SFTP_HAB0,MAP_HAB0,ADMIN_TOOLS">
         <a href="#/administration/appconfiguration" data-active-link="administration,checkconfiguration,ocrlangconfiguration,filesgestion,workflow/group,workflow/model,platformconfiguration">
             <span class="menu-label sem-auto-hide" translate>Administration</span> <span class="glyphicon syrtis-icon-prefs" tooltip-placement="auto right" uib-tooltip="{{::'Administration' | translate}}"></span>
         </a>

--- a/src/main/webapp/scripts/configuration.js
+++ b/src/main/webapp/scripts/configuration.js
@@ -189,6 +189,7 @@
 
         // Administration
         ADMINISTRATION_LIB: 'ADMINISTRATION-LIB', // Visualisation des données des autres bibliothèques
+        ADMIN_TOOLS: 'ADMIN-TOOLS', // Accès aux outils d'administration
         CONF_INTERNET_ARCHIVE_HAB0: 'CONF-INTERNET-ARCHIVE-HAB0', // Habilitation configuration Internet Archive: lecture
         CONF_INTERNET_ARCHIVE_HAB1: 'CONF-INTERNET-ARCHIVE-HAB1', // Habilitation configuration Internet Archive: création / modification
         CONF_INTERNET_ARCHIVE_HAB2: 'CONF-INTERNET-ARCHIVE-HAB2', // Habilitation configuration Internet Archive: suppression


### PR DESCRIPTION
Currently, admin tools (Workflow tools and Project tools) are only available to the SUPER_ADMIN user.

This patch adds a new ADMIN_TOOLS permission which gives access to these tools when enabled in a profile

Test plan:

 - Execute the database update

 - As a normal user, check that you don't have access to admin tools
   ("Outils Admin" in /administration/appconfiguration)

 - As admin, edit the profile used by the normal user and add the following authorization: 
   ADMIN-TOOLS - Accès aux outils d'administration

 - As the normal user, check that you do have access to admin tools:
   Outils Admin:
    Outils Workflow - Mises à jour workflow
    Outils Projet / Lot - (Dé)clôturer 1 lot / 1 projet